### PR TITLE
Allow processing import from empty query.

### DIFF
--- a/src/DataSource/Loader/BulkSqlDataLoader.php
+++ b/src/DataSource/Loader/BulkSqlDataLoader.php
@@ -46,6 +46,8 @@ class BulkSqlDataLoader implements DataLoaderInterface
     {
         $this->setUpConnection();
         $this->setUpImportFilePath();
+
+
         $queryBuilder = $this->databaseConnection->createQueryBuilder();
         $queryBuilder->select($this->select)
             ->from($this->from);
@@ -65,12 +67,21 @@ class BulkSqlDataLoader implements DataLoaderInterface
         $filesystemLocal = new Filesystem(new LocalFilesystemAdapter('/'));
         $stream = fopen('php://temp', 'r+');
         $columnNamesAdded = false;
+
+
+
         while (($result = $results->fetchAssociative()) !== false) {
             if (!$columnNamesAdded) {
                 fputcsv($stream, array_keys($result));
                 $columnNamesAdded = true;
             }
             fputcsv($stream, $result);
+        }
+
+        // if no column names were added, add an empty line
+        if (!$columnNamesAdded) {
+            fputcsv($stream, ['']);
+            Logger::info('No results from query: ' . $queryBuilder->getSQL());
         }
 
         rewind($stream);

--- a/src/DataSource/Loader/BulkSqlDataLoader.php
+++ b/src/DataSource/Loader/BulkSqlDataLoader.php
@@ -5,15 +5,12 @@ declare(strict_types=1);
 namespace TorqIT\DataImporterExtensionsBundle\DataSource\Loader;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Exception;
 use League\Flysystem\Filesystem;
-use League\Flysystem\FilesystemException;
 use League\Flysystem\Local\LocalFilesystemAdapter;
+use Symfony\Component;
 use Pimcore;
 use Pimcore\Bundle\DataImporterBundle\DataSource\Loader\DataLoaderInterface;
 use Pimcore\Bundle\DataImporterBundle\Exception\InvalidConfigurationException;
-use Pimcore\Logger;
-use Symfony\Component;
 use TorqIT\DataImporterExtensionsBundle\Exception\FetchDatabaseDataException;
 use TorqIT\DataImporterExtensionsBundle\Exception\InvalidConnectionException;
 use TorqIT\DataImporterExtensionsBundle\Exception\NotResourceException;
@@ -76,7 +73,6 @@ class BulkSqlDataLoader implements DataLoaderInterface
         // if no column names were added, add an empty line
         if (!$columnNamesAdded) {
             fputcsv($stream, ['']);
-            Logger::info('No results from query: ' . $queryBuilder->getSQL());
         }
 
         rewind($stream);

--- a/src/DataSource/Loader/BulkSqlDataLoader.php
+++ b/src/DataSource/Loader/BulkSqlDataLoader.php
@@ -46,8 +46,6 @@ class BulkSqlDataLoader implements DataLoaderInterface
     {
         $this->setUpConnection();
         $this->setUpImportFilePath();
-
-
         $queryBuilder = $this->databaseConnection->createQueryBuilder();
         $queryBuilder->select($this->select)
             ->from($this->from);
@@ -67,9 +65,6 @@ class BulkSqlDataLoader implements DataLoaderInterface
         $filesystemLocal = new Filesystem(new LocalFilesystemAdapter('/'));
         $stream = fopen('php://temp', 'r+');
         $columnNamesAdded = false;
-
-
-
         while (($result = $results->fetchAssociative()) !== false) {
             if (!$columnNamesAdded) {
                 fputcsv($stream, array_keys($result));


### PR DESCRIPTION
When SQL query results in no data, write an empty line to the temporary CSV file to allow import processing to continue.