### PR TITLE
ImageGalleryAppender empty check

### DIFF
--- a/src/Mapping/DataTarget/ImageGalleryAppender.php
+++ b/src/Mapping/DataTarget/ImageGalleryAppender.php
@@ -39,6 +39,10 @@ class ImageGalleryAppender extends Direct
      */
     public function assignData(ElementInterface $element, $data): void
     {
+        if (empty($data->getItems())) {
+            return;
+        }
+        
         $setterParts = explode('.', $this->fieldName);
         $valueContainer = null;
 


### PR DESCRIPTION
Sometimes when referencing a dynamic column, the resulting value will be null/empty - this fix suppresses an error from being thrown when the ImageHalleryAppender tries to access the image via the following line (83): `$newImage = $data->getItems()[0];`

Tested this out by appending new images to a gallery, modifying the import mappings to reference a column that doesn't exist, then re-running the import - the resulting gallery wasn't modified and still contained the previously appended images.